### PR TITLE
Fixed bookmark drives issue

### DIFF
--- a/marlin/scripts/marlin.bat
+++ b/marlin/scripts/marlin.bat
@@ -26,7 +26,7 @@ marlin_help
 exit /b 0
 
 :CD
-cd %bname%
+cd /d %bname%
 exit /b 0
 
 :END


### PR DESCRIPTION
This fixes issue #8 by adding /d to the marlin.bat script file.